### PR TITLE
Resolving  Compatibility Issue between python2 and python3

### DIFF
--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -34,8 +34,8 @@ import math
 import operator
 import numpy as np
 
-import bezier
-import minjerk
+from . import bezier
+from . import minjerk
 
 import rospy
 

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -28,6 +28,8 @@
 """
 Baxter RSDK Joint Trajectory Action Server
 """
+from __future__ import absolute_import
+
 import bisect
 from copy import deepcopy
 import math

--- a/src/joint_trajectory_action/joint_trajectory_action.py
+++ b/src/joint_trajectory_action/joint_trajectory_action.py
@@ -58,6 +58,11 @@ import baxter_dataflow
 import baxter_interface
 
 
+# Python2's xrange equals Python3's range, and xrange is removed on Python3
+if not hasattr(__builtins__, 'xrange'):
+    xrange = range
+
+
 class JointTrajectoryActionServer(object):
     def __init__(self, limb, reconfig_server, rate=100.0,
                  mode='position_w_id', interpolation='bezier'):
@@ -203,10 +208,11 @@ class JointTrajectoryActionServer(object):
         self._fdbk.desired.time_from_start = rospy.Duration.from_sec(cur_time)
         self._fdbk.actual.positions = self._get_current_position(jnt_names)
         self._fdbk.actual.time_from_start = rospy.Duration.from_sec(cur_time)
-        self._fdbk.error.positions = map(operator.sub,
-                                         self._fdbk.desired.positions,
-                                         self._fdbk.actual.positions
-                                        )
+        self._fdbk.error.positions = list(map(operator.sub,
+                                              self._fdbk.desired.positions,
+                                              self._fdbk.actual.positions
+                                             )
+                                         )
         self._fdbk.error.time_from_start = rospy.Duration.from_sec(cur_time)
         self._server.publish_feedback(self._fdbk)
 


### PR DESCRIPTION
**Description**
This Pull Request includes modifications to ensure compatibility with both Python2 and Python3. 
This modification is required for launching `baxter_default.launch` of `jsk_baxter_startup` in the Noetic environment.

**Modification Details**
1. import statements  `import bezier` and `import minzerk`  have been changed to `from . import bezier` and `from . import minzerk` .
2. xrange has been replaced with range.
3. The map() function has been modified to use list(map()).

**Testing**
The changes have been tested successfully, demonstrating proper functionality with both Python2 and Python3.

@pazeshun